### PR TITLE
Falsch benutzte Variable

### DIFF
--- a/Script/folgen-und-reihen.tex
+++ b/Script/folgen-und-reihen.tex
@@ -725,7 +725,7 @@ ist und damit dann auch eine untere Schranke der Folge $(a_n)_{n\in\mathbb{N}}$.
 alle $n \in \mathbb{N}$
 \\[0.2cm]
 \hspace*{1.3cm}
-$s - \varepsilon < s - \frac{1}{2} \cdot s \leq a_n$.
+$s - \varepsilon < s - \frac{1}{2} \cdot \varepsilon \leq a_n$.
 \\[0.2cm]
 Damit haben wir insgesamt
 \\[0.2cm]


### PR DESCRIPTION
Im Skript steht im Moment:
s - epsilon < s - 0.5\* s < a_n

Es müsste jedoch heißen:

s - epsilon < s - 0.5\* epsilon < a_n
