### PR TITLE
Formatierungsänderung

### DIFF
--- a/Script/irrational.tex
+++ b/Script/irrational.tex
@@ -417,7 +417,7 @@ $0 < I_n < 1$.
 Das ist aber ein Widerspruch dazu, dass wir oben nachgewiesen haben, dass $I_n$ eine ganze Zahl ist.  \qed
 
 \section{Tranzendente Zahlen}
-\begin{Definition}(Algebraische Zahlen) \lb
+\begin{Definition}[Algebraische Zahlen] \lb
 Eine Zahl $r \in \mathbb{R}$ hei{\ss}t \emph{algebraisch} genau dann, wenn es ein Polynom
 \\[0.2cm]
 \hspace*{1.3cm}


### PR DESCRIPTION
Definition der Algebraische Zahlen als Name für die Definition derselben übernehmen. Hat den Vorteil das der Name der Definition bei einem Listing der Definitionen auftaucht.
![capture](https://cloud.githubusercontent.com/assets/20282916/18248730/644cb384-737a-11e6-9f7c-b57022ecdef9.PNG)